### PR TITLE
Fix deprecated requirement (google-generativeai)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 huggingface_hub
 transformers
-google-generativeai
+google-genai
 Pillow
 python-dotenv
 requests # Added for API calls


### PR DESCRIPTION
Replacing google-generativeai requirement (deprecated) by google-genai

Closes #1 